### PR TITLE
Corrected Transaction::setValue() to fix issue #6

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -99,7 +99,11 @@ class Transaction extends EthDataType {
     }
   }
 
-  public function setValue(EthQ $value){
+    /**
+     * @param EthQ $value
+     * @param array $params
+     */
+    public function setValue($value, array $params = []){
     if (is_object($value) && is_a($value, 'EthQ')) {
       $this->value = $value;
     }


### PR DESCRIPTION
This fixes the type declaration issue mentioned in issue #6.

Added PhpDoc comment to this method to indicate what the values should be.

`Ethereum\Transaction`'s declaration of method values should match the extended function on `Ethereum\EthDataType`.

------------

`Ethereum\Transaction`
```php
public function setValue(EthQ $value){
```
`Ethereum\EthDataType`
```php
public function setValue($val, array $params = array()) {
```