### PR TITLE
remove leading zero digits

### DIFF
--- a/src/DataType/EthBlockParam.php
+++ b/src/DataType/EthBlockParam.php
@@ -105,7 +105,8 @@ class EthBlockParam extends EthQ
         } else {
             $val = intval($this->value->toString());
             $val = ($val === 0) ? $val : $this->value->toHex(false);
-
+            $val = ltrim($val,0);
+            
             // Unpaded positive Hex value.
             return $this->ensureHexPrefix($val);
         }


### PR DESCRIPTION
eth_getBlockByNumber return error : invalid argument 0: hex number with leading zero digits fix.I
I find the reason is   leading zero digits.
for example     

$ethBlockParam = new EthBlockParam(13);
$blockData = $eth->eth_getBlockByNumber($ethBlockParam,new EthB(true));

the request params data  is:

array(2) {
  [0]=>
  string(4) " **_0x0d_**"
  [1]=>
  bool(true)
}

it  return error : invalid argument 0: hex number with leading zero digits fix

it should be array(2) {
  [0]=>
  string(4) "**_0xd_**"
  [1]=>
  bool(true)
}

i try fix it with remove the 0;

