### PR TITLE
Enabled rpc_error option in RpcClient

### DIFF
--- a/src/Ethereum.php
+++ b/src/Ethereum.php
@@ -74,7 +74,8 @@ class Ethereum extends EthereumStatic implements Web3Interface
 
       $this->client = RpcClient::factory($url, [
             // Debug JsonRPC requests.
-            'debug' => false,
+            'debug'     => false,
+            'rpc_error' => true,
         ]);
 
         $this->definition = self::getDefinition();


### PR DESCRIPTION
We should throw Exception on RPC Error.

Right now it just returns NULL on Error.

TODO: think about custom Exceptions