### PR TITLE
This would be more ideal if the user wants to send parameters for guzzleHttp.

### DIFF
--- a/src/Ethereum.php
+++ b/src/Ethereum.php
@@ -68,15 +68,15 @@ class Ethereum extends EthereumStatic implements Web3Interface
      */
     public function __construct(string $url = 'http://localhost:8545', array $config = [])
     {
-      // Require the workaround helpers, as autoload files in composer
-      //   doesn't work as expected.
-      require_once __DIR__ . '/helpers/ethereum-client-workaround-helpers.php';
+        // Require the workaround helpers, as autoload files in composer
+        //   doesn't work as expected.
+        require_once __DIR__ . '/helpers/ethereum-client-workaround-helpers.php';
 
-      $this->client = RpcClient::factory($url, array_merge([
-        // Debug JsonRPC requests.
-        'debug'     => false,
-        'rpc_error' => true,
-    ], $config));
+        $this->client = RpcClient::factory($url, array_merge([
+            // Debug JsonRPC requests.
+            'debug'     => false,
+            'rpc_error' => true,
+        ], $config));
 
         $this->definition = self::getDefinition();
 

--- a/src/Ethereum.php
+++ b/src/Ethereum.php
@@ -66,17 +66,17 @@ class Ethereum extends EthereumStatic implements Web3Interface
      *   Connection to Ethereum node. E.g:
      *   http://localhost:8545 or https://mainnet.infura.io/drupal.
      */
-    public function __construct(string $url = 'http://localhost:8545')
+    public function __construct(string $url = 'http://localhost:8545', array $config = [])
     {
       // Require the workaround helpers, as autoload files in composer
       //   doesn't work as expected.
       require_once __DIR__ . '/helpers/ethereum-client-workaround-helpers.php';
 
-      $this->client = RpcClient::factory($url, [
-            // Debug JsonRPC requests.
-            'debug'     => false,
-            'rpc_error' => true,
-        ]);
+      $this->client = RpcClient::factory($url, array_merge([
+        // Debug JsonRPC requests.
+        'debug'     => false,
+        'rpc_error' => true,
+    ], $config));
 
         $this->definition = self::getDefinition();
 


### PR DESCRIPTION
Hello, if we want to send parameters for guzzleHttp, we need to edit the code. With this change, the user can do this while creating the class.