### PR TITLE
Adding support for functions with underscores in their names

### DIFF
--- a/src/EthereumStatic.php
+++ b/src/EthereumStatic.php
@@ -105,8 +105,8 @@ abstract class EthereumStatic
     public static function isValidFunction($input)
     {
         // Check for function and Params.
-        // See: https://regex101.com/r/437FZz/4
-        $regex = '/^[a-zA-Z]+[a-zA-Z0-9]*[\(]{1}(([\w\d\[\]*){1}(\,[\w\d\[\]]*[\w\d\[\]]*)*)[\)]{1}$/';
+        // See: https://regex101.com/r/7KRDNT/1
+        $regex = '/^[a-zA-Z_]+[a-zA-Z0-9_]*[\(]{1}(([\w\d\[\]*){1}(\,[\w\d\[\]]*[\w\d\[\]]*)*)[\)]{1}$/';
         if (is_string($input) && preg_match($regex, $input) === 1) {
             return true;
         }


### PR DESCRIPTION
Without this change trying to call a function with `_` in its name fails with a `No valid (solidity) signature string provided.` error.