### PR TITLE
Parameters should be padded to be 32 bytes wide

### DIFF
--- a/src/Abi.php
+++ b/src/Abi.php
@@ -46,7 +46,7 @@ class Abi extends EthereumStatic
         foreach ($values as $i => $val) {
             $expectedType = $m->inputs[$i]->type;
             $validAbiType = self::convertByAbi($expectedType, $val);
-            $params .= EthereumStatic::removeHexPrefix($validAbiType->encodedHexVal());
+            $params .= str_pad(EthereumStatic::removeHexPrefix($validAbiType->encodedHexVal()), 64, "0", STR_PAD_LEFT);
         }
         return new EthD($params);
     }


### PR DESCRIPTION
At least binance RPC doesn't work if the parameters aren't padded to be 32 bytes wide as according to the spec https://docs.soliditylang.org/en/latest/abi-spec.html